### PR TITLE
Suggest installing with pip

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ The library currently supports [version 0.4.0][2] of the specs and runs with Pyt
 
 Install:
 
-    easy_install pytoml
+    pip install pytoml
 
 The interface is the same as for the standard `json` package.
 


### PR DESCRIPTION
The Python Packaging User Guide recommends installing packages with pip.
See https://packaging.python.org/en/latest/installing.html#use-pip-for-installing