### PR TITLE
Strip underscores for int() and float()

### DIFF
--- a/pytoml/parser.py
+++ b/pytoml/parser.py
@@ -264,10 +264,11 @@ def _p_value(s):
 
     if s.consume_re(_float_re):
         m = s.last().group(0)
+        r = m.replace('_','')
         if '.' in m or 'e' in m or 'E' in m:
-            return 'float', m, float(m), pos
+            return 'float', m, float(r), pos
         else:
-            return 'int', m, int(m, 10), pos
+            return 'int', m, int(r, 10), pos
 
     if s.consume('['):
         items = []


### PR DESCRIPTION
Fixes a parse failure on integers/floats with underscores.

While the script has no problem detecting numbers with underscores, `_p_value` would choke right before returning them due to the strings being passed unmodified into `int()` and `float()`.

BTW, [I wrote some toml-test tests for underscores here](https://github.com/ExpHP/toml-test/commits/0.4-numeric-tests) while doing this. I see you have a similar setup, so I can maybe add or PR the relevant stuff if you want.