### PR TITLE
Feature/write null values as comments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 build/
 dist/
 pytoml.egg-info/
+venv/
+.idea/
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -27,6 +27,16 @@ Use `dump` or `dumps` to serialize a dict into TOML.
 
     >>> print toml.dumps(obj)
     a = 1
+    
+## tests
+
+To run the tests update the `toml-test` submodule:
+
+    $ git submodule update --init --recursive
+    
+Then run the tests:
+
+    $ python test/test.py
 
   [1]: https://github.com/toml-lang/toml
   [2]: https://github.com/toml-lang/toml/blob/master/versions/en/toml-v0.4.0.md

--- a/pytoml/writer.py
+++ b/pytoml/writer.py
@@ -5,16 +5,20 @@ if sys.version_info[0] == 3:
     long = int
     unicode = str
 
+
 def dumps(obj):
     fout = io.StringIO()
     dump(fout, obj)
     return fout.getvalue()
 
-_escapes = { '\n': 'n', '\r': 'r', '\\': '\\', '\t': 't', '\b': 'b', '\f': 'f', '"': '"' }
+
+_escapes = {'\n': 'n', '\r': 'r', '\\': '\\', '\t': 't', '\b': 'b', '\f': 'f', '"': '"'}
+
 
 def _escape_string(s):
     res = []
     start = 0
+
     def flush():
         if start != i:
             res.append(s[start:i])
@@ -34,13 +38,16 @@ def _escape_string(s):
     flush()
     return '"' + ''.join(res) + '"'
 
+
 def _escape_id(s):
     if any(not c.isalnum() and c not in '-_' for c in s):
         return _escape_string(s)
     return s
 
+
 def _format_list(v):
     return '[{}]'.format(', '.join(_format_value(obj) for obj in v))
+
 
 def _format_value(v):
     if isinstance(v, bool):
@@ -73,6 +80,7 @@ def _format_value(v):
         return _format_list(v)
     else:
         raise RuntimeError(v)
+
 
 def dump(fout, obj):
     tables = [((), obj, False)]

--- a/pytoml/writer.py
+++ b/pytoml/writer.py
@@ -101,8 +101,9 @@ def dump(fout, obj):
             elif isinstance(v, list) and v and all(isinstance(o, dict) for o in v):
                 tables.extend((name + (k,), d, True) for d in reversed(v))
             elif v is None:
+                # based on mojombo's comment: https://github.com/toml-lang/toml/issues/146#issuecomment-25019344
                 fout.write(
-                    '#{} = VALUE  # To use: uncomment and replace VALUE with your own value.\n'.format(_escape_id(k)))
+                    '#{} = null  # To use: uncomment and replace null with value\n'.format(_escape_id(k)))
             else:
                 fout.write('{} = {}\n'.format(_escape_id(k), _format_value(v)))
 

--- a/pytoml/writer.py
+++ b/pytoml/writer.py
@@ -100,6 +100,9 @@ def dump(fout, obj):
                 tables.append((name + (k,), v, False))
             elif isinstance(v, list) and v and all(isinstance(o, dict) for o in v):
                 tables.extend((name + (k,), d, True) for d in reversed(v))
+            elif v is None:
+                fout.write(
+                    '#{} = VALUE  # To use: uncomment and replace VALUE with your own value.\n'.format(_escape_id(k)))
             else:
                 fout.write('{} = {}\n'.format(_escape_id(k), _format_value(v)))
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 
 setup(
     name='pytoml',
-    version='0.1.4',
+    version='0.1.5',
 
     description='A parser for TOML-0.4.0',
     author='Martin Vejnár',


### PR DESCRIPTION
This PR adds the ability to parse dictionaries with some `None` values without crashing.  I looked to see if there were any comments in the main toml project about this and I came up with this:

https://github.com/toml-lang/toml/issues/146#issuecomment-25019344

Now the `dump` function will still print `#key = null` when a null value is encountered.  This is particularly useful when printing out an example configuration file from a command line utility.