### PR TITLE
Feature/add sort keys

### DIFF
--- a/pytoml/writer.py
+++ b/pytoml/writer.py
@@ -87,9 +87,9 @@ def dump(fout, obj, sort_keys=False):
 
     while tables:
         if sort_keys is True:
-            tables.sort(key=lambda tup: tup[0])
+            tables.sort(key=lambda tup: tup[0], reverse=True)
 
-        name, table, is_array = tables.pop(0)
+        name, table, is_array = tables.pop()
         if name:
             section_name = '.'.join(_escape_id(c) for c in name)
             if is_array:

--- a/pytoml/writer.py
+++ b/pytoml/writer.py
@@ -89,7 +89,7 @@ def dump(fout, obj, sort_keys=False):
         if sort_keys is True:
             tables.sort(key=lambda tup: tup[0])
 
-        name, table, is_array = tables.pop()
+        name, table, is_array = tables.pop(0)
         if name:
             section_name = '.'.join(_escape_id(c) for c in name)
             if is_array:

--- a/pytoml/writer.py
+++ b/pytoml/writer.py
@@ -97,7 +97,8 @@ def dump(fout, obj, sort_keys=False):
             else:
                 fout.write('[{}]\n'.format(section_name))
 
-        for k in table:
+        table_keys = sorted(table.keys()) if sort_keys is True else table.keys()
+        for k in table_keys:
             v = table[k]
             if isinstance(v, dict):
                 tables.append((name + (k,), v, False))

--- a/pytoml/writer.py
+++ b/pytoml/writer.py
@@ -6,9 +6,9 @@ if sys.version_info[0] == 3:
     unicode = str
 
 
-def dumps(obj):
+def dumps(obj, sort_keys=False):
     fout = io.StringIO()
-    dump(fout, obj)
+    dump(fout, obj, sort_keys)
     return fout.getvalue()
 
 
@@ -82,7 +82,7 @@ def _format_value(v):
         raise RuntimeError(v)
 
 
-def dump(fout, obj):
+def dump(fout, obj, sort_keys=False):
     tables = [((), obj, False)]
 
     while tables:
@@ -109,3 +109,6 @@ def dump(fout, obj):
 
         if tables:
             fout.write('\n')
+
+        if sort_keys is True:
+            tables.sort(key=lambda tup: tup[0])

--- a/pytoml/writer.py
+++ b/pytoml/writer.py
@@ -8,7 +8,7 @@ if sys.version_info[0] == 3:
 
 def dumps(obj, sort_keys=False):
     fout = io.StringIO()
-    dump(fout, obj, sort_keys)
+    dump(fout, obj, sort_keys=sort_keys)
     return fout.getvalue()
 
 
@@ -86,7 +86,7 @@ def dump(fout, obj, sort_keys=False):
     tables = [((), obj, False)]
 
     while tables:
-        if sort_keys is True:
+        if sort_keys:
             tables.sort(key=lambda tup: tup[0], reverse=True)
 
         name, table, is_array = tables.pop()
@@ -97,7 +97,7 @@ def dump(fout, obj, sort_keys=False):
             else:
                 fout.write('[{}]\n'.format(section_name))
 
-        table_keys = sorted(table.keys()) if sort_keys is True else table.keys()
+        table_keys = sorted(table.keys()) if sort_keys else table.keys()
         for k in table_keys:
             v = table[k]
             if isinstance(v, dict):

--- a/pytoml/writer.py
+++ b/pytoml/writer.py
@@ -86,6 +86,9 @@ def dump(fout, obj, sort_keys=False):
     tables = [((), obj, False)]
 
     while tables:
+        if sort_keys is True:
+            tables.sort(key=lambda tup: tup[0])
+
         name, table, is_array = tables.pop()
         if name:
             section_name = '.'.join(_escape_id(c) for c in name)
@@ -109,6 +112,3 @@ def dump(fout, obj, sort_keys=False):
 
         if tables:
             fout.write('\n')
-
-        if sort_keys is True:
-            tables.sort(key=lambda tup: tup[0])

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 
 setup(
     name='pytoml',
-    version='0.1.6',
+    version='0.1.7',
 
     description='A parser for TOML-0.4.0',
     author='Martin Vejnár',

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 
 setup(
     name='pytoml',
-    version='0.1.5',
+    version='0.1.6',
 
     description='A parser for TOML-0.4.0',
     author='Martin Vejnár',


### PR DESCRIPTION
This pull-request adds the `sort_keys` argument to the `dump` and `dumps` functions.  It is set to `False` by default.  Behavior is similar to `sort_keys` in the `json.dump` and `json.dumps` functions.