### PR TITLE
Sort keys tests

### DIFF
--- a/pytoml/writer.py
+++ b/pytoml/writer.py
@@ -91,9 +91,15 @@ def _format_value(v):
 def dump(fout, obj, sort_keys=False):
     tables = [((), obj, False)]
 
+    def table_cmp(a, b):
+        """don't re-order arrays"""
+        if a[2] and b[2]:   # if both are arrays
+            return 0        # don't re-order
+        return cmp(a[0], b[0])
+
     while tables:
         if sort_keys:
-            tables.sort(key=lambda tup: tup[0], reverse=True)
+            tables.sort(cmp=table_cmp, reverse=True)
         name, table, is_array = tables.pop()
         if name:
             section_name = '.'.join(_escape_id(c) for c in name)
@@ -102,7 +108,10 @@ def dump(fout, obj, sort_keys=False):
             else:
                 fout.write('[{0}]\n'.format(section_name))
 
-        table_keys = sorted(table.keys()) if sort_keys else table.keys()
+        if sort_keys and not is_array:
+            table_keys = sorted(table.keys())
+        else:
+            table_keys = table.keys()
         for k in table_keys:
             v = table[k]
             if isinstance(v, dict):

--- a/test/test.py
+++ b/test/test.py
@@ -40,7 +40,9 @@ def adjust_bench(v):
 def _main():
     ap = argparse.ArgumentParser()
     ap.add_argument('-d', '--dir', action='append')
+    ap.add_argument('-s', '--sort-keys', action='store_true')
     ap.add_argument('testcase', nargs='*')
+    ap.set_defaults(sort_keys=False)
     args = ap.parse_args()
 
     if not args.dir:
@@ -69,7 +71,7 @@ def _main():
                     parsed = None
                     parse_error = sys.exc_info()
                 else:
-                    dumped = toml.dumps(parsed)
+                    dumped = toml.dumps(parsed, sort_keys=args.sort_keys)
                     parsed2 = toml.loads(dumped)
                     if parsed != parsed2:
                         failed.append((fname, parsed, parsed2, None))

--- a/test/test.py
+++ b/test/test.py
@@ -72,7 +72,7 @@ def _main():
                     dumped = toml.dumps(parsed)
                     parsed2 = toml.loads(dumped)
                     if parsed != parsed2:
-                        failed.append((fname, None))
+                        failed.append((fname, parsed, parsed2, None))
                         continue
 
                     with open(os.path.join(top, fname), 'rb') as fin:
@@ -90,7 +90,11 @@ def _main():
                     succeeded.append(fname)
 
     for f, parsed, bench, e in failed:
-        print('failed: {}\n{}\n{}'.format(f, json.dumps(parsed, indent=4), json.dumps(bench, indent=4)))
+        try:
+            print('failed: {}\n{}\n{}'.format(f, json.dumps(parsed, indent=4), json.dumps(bench, indent=4)))
+        except TypeError:
+            print('failed: {}\n{}\n{}'.format(f, parsed, bench))
+
         if e:
             traceback.print_exception(*e)
     print('succeeded: {0}'.format(len(succeeded)))


### PR DESCRIPTION
This builds upon (and includes #20) by adding the ability to run the tests with sort-keys enabled.

It also fixes a bug in dump's `sort_keys=True` mode which breaks nested table arrays:

For this test input:
```
[[albums]]
name = "Born to Run"

  [[albums.songs]]
  name = "Jungleland"

  [[albums.songs]]
  name = "Meeting Across the River"

[[albums]]
name = "Born in the USA"
  
  [[albums.songs]]
  name = "Glory Days"

  [[albums.songs]]
  name = "Dancing in the Dark"
```
the table name sorting would produce:
```
[[albums]]
name = "Born to Run"

[[albums]]
name = "Born in the USA"
  
  [[albums.songs]]
  name = "Jungleland"

  [[albums.songs]]
  name = "Meeting Across the River"

  [[albums.songs]]
  name = "Glory Days"

  [[albums.songs]]
  name = "Dancing in the Dark"

```
which instead of yielding this correct JSON:
```JSON
{
    "albums": [
        {
            "name": "Born to Run", 
            "songs": [
                {
                    "name": "Jungleland"
                }, 
                {
                    "name": "Meeting Across the River"
                }
            ]
        }, 
        {
            "name": "Born in the USA", 
            "songs": [
                {
                    "name": "Glory Days"
                }, 
                {
                    "name": "Dancing in the Dark"
                }
            ]
        }
    ]
}
```
produced this broken json:
```JSON
{
    "albums": [
        {
            "name": "Born to Run"
        }, 
        {
            "name": "Born in the USA", 
            "songs": [
                {
                    "name": "Glory Days"
                }, 
                {
                    "name": "Dancing in the Dark"
                }, 
                {
                    "name": "Jungleland"
                }, 
                {
                    "name": "Meeting Across the River"
                }
            ]
        }
    ]
}
```
With these fixed to writer.py the test passes and the output is correct.