### PR TITLE
fix float dumping

### DIFF
--- a/pytoml/writer.py
+++ b/pytoml/writer.py
@@ -61,7 +61,7 @@ def _format_value(v):
     if isinstance(v, int) or isinstance(v, long):
         return unicode(v)
     if isinstance(v, float):
-        return '{0:.17f}'.format(v)
+        return repr(v)
     elif isinstance(v, unicode) or isinstance(v, bytes):
         return _escape_string(v)
     elif isinstance(v, datetime.datetime):


### PR DESCRIPTION
Use `repr` rather than `{0:.17f}` to dump `float`s.
This automatically turns on the [scientific notation](https://github.com/toml-lang/toml/issues/54) when appropriate, and always gives the full (i.e. not more, not less) precision.
See also: https://github.com/uiri/toml/issues/15
