### PR TITLE
Include LICENSE in sdist tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE


### PR DESCRIPTION
Technically, it probably doesn't need to be redistributed,
yet distributing the tarball gets easier if this is in it.