### PR TITLE
Tabs in multiline literal strings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ __pycache__/
 .tox/
 *.pyc
 .cache/
+.vscode/
+.pytest_cache/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: python
 python:
-    - "2.6"
     - "2.7"
     - "3.4"
     - "3.5"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 # pytoml
 
 This project aims at being a specs-conforming and strict parser and writer for [TOML][1] files.
-The library currently supports [version 0.4.0][2] of the specs and runs with Python 2.6+ and 3.4+.
+The library currently supports [version 0.4.0][2] of the specs and runs with Python 2.7+ and 3.4+.
 
 Install:
 

--- a/pytoml/parser.py
+++ b/pytoml/parser.py
@@ -223,8 +223,8 @@ _float_re = re.compile(r'[+-]?(?:0|[1-9](?:_?\d)*)(?:\.\d(?:_?\d)*)?(?:[eE][+-]?
 _datetime_re = re.compile(r'(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(\.\d+)?(?:Z|([+-]\d{2}):(\d{2}))')
 
 _basicstr_ml_re = re.compile(r'(?:(?:|"|"")[^"\\\000-\011\013-\037])*')
-_litstr_re = re.compile(r"[^'\000-\037]*")
-_litstr_ml_re = re.compile(r"(?:(?:|'|'')(?:[^'\000-\011\013-\037]))*")
+_litstr_re = re.compile(r"[^'\000\010\012-\037]*")
+_litstr_ml_re = re.compile(r"(?:(?:|'|'')(?:[^'\000-\010\013-\037]))*")
 def _p_value(s, object_pairs_hook):
     pos = s.pos()
 

--- a/setup.py
+++ b/setup.py
@@ -22,13 +22,12 @@ setup(
     classifiers=[
         # Supported python versions
         'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
 
         # License
         'License :: OSI Approved :: MIT License',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,py34,py35,py36
+envlist = py27,py34,py35,py36,py37
 [testenv]
 deps = -r{toxinidir}/dev-requirements.txt
 commands=


### PR DESCRIPTION
According to the specs, unescaped tabs are allowed in literal strings. Resolves #46.