### PR TITLE
Write pathlib objects as strings

### DIFF
--- a/pytoml/writer.py
+++ b/pytoml/writer.py
@@ -1,6 +1,8 @@
 from __future__ import unicode_literals
 import io, datetime, math, sys
-from pathlib import PurePath
+
+if sys.version_info >= (3, 4):
+    from pathlib import PurePath
 
 if sys.version_info[0] == 3:
     long = int
@@ -88,10 +90,17 @@ def _format_value(v):
             return v.strftime('%Y-%m-%dT%H:%M:%S') + suffix
     elif isinstance(v, list):
         return _format_list(v)
-    elif isinstance(v, PurePath):
+    elif _isinstance_purepath(v):
         return '"{}"'.format(v)
     else:
         raise RuntimeError(v)
+
+
+def _isinstance_purepath(v):
+    if sys.version_info >= (3, 4) and isinstance(v, PurePath):
+        return True
+    else:
+        return False
 
 
 def dump(obj, fout, sort_keys=False):

--- a/pytoml/writer.py
+++ b/pytoml/writer.py
@@ -1,8 +1,11 @@
 from __future__ import unicode_literals
 import io, datetime, math, sys
 
-if sys.version_info >= (3, 4):
-    from pathlib import PurePath
+try:
+    from pathlib import PurePath as _path_types
+except ImportError:
+    _path_types = ()
+
 
 if sys.version_info[0] == 3:
     long = int
@@ -90,17 +93,10 @@ def _format_value(v):
             return v.strftime('%Y-%m-%dT%H:%M:%S') + suffix
     elif isinstance(v, list):
         return _format_list(v)
-    elif _isinstance_purepath(v):
+    elif isinstance(v, _path_types):
         return _escape_string(str(v))
     else:
         raise RuntimeError(v)
-
-
-def _isinstance_purepath(v):
-    if sys.version_info >= (3, 4) and isinstance(v, PurePath):
-        return True
-    else:
-        return False
 
 
 def dump(obj, fout, sort_keys=False):

--- a/pytoml/writer.py
+++ b/pytoml/writer.py
@@ -91,7 +91,7 @@ def _format_value(v):
     elif isinstance(v, list):
         return _format_list(v)
     elif _isinstance_purepath(v):
-        return '"{}"'.format(v)
+        return _escape_string(str(v))
     else:
         raise RuntimeError(v)
 

--- a/pytoml/writer.py
+++ b/pytoml/writer.py
@@ -1,5 +1,6 @@
 from __future__ import unicode_literals
 import io, datetime, math, sys
+from pathlib import PurePath
 
 if sys.version_info[0] == 3:
     long = int
@@ -87,6 +88,8 @@ def _format_value(v):
             return v.strftime('%Y-%m-%dT%H:%M:%S') + suffix
     elif isinstance(v, list):
         return _format_list(v)
+    elif isinstance(v, PurePath):
+        return '"{}"'.format(v)
     else:
         raise RuntimeError(v)
 

--- a/test/test_writer.py
+++ b/test/test_writer.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+import pathlib
 
 import pytest
 
@@ -13,3 +14,12 @@ import pytoml as toml
 def test_attempting_to_write_non_number_floats_raises_error(value):
     error = pytest.raises(ValueError, lambda: toml.dumps({"value": value}))
     assert str(error.value) == "{0} is not a valid TOML value".format(value)
+
+
+@pytest.mark.parametrize("value", [
+    pathlib.PurePath("test-path"),
+    pathlib.Path("test-path"),
+])
+def test_pathlib_path_objects_are_written_as_strings(value):
+    path_value = toml.dumps({"value": value})
+    assert path_value == 'value = "test-path"\n'

--- a/test/test_writer.py
+++ b/test/test_writer.py
@@ -1,5 +1,4 @@
 from __future__ import unicode_literals
-import pathlib
 
 import pytest
 
@@ -16,10 +15,13 @@ def test_attempting_to_write_non_number_floats_raises_error(value):
     assert str(error.value) == "{0} is not a valid TOML value".format(value)
 
 
-@pytest.mark.parametrize("value", [
-    pathlib.PurePath("test-path"),
-    pathlib.Path("test-path"),
-])
-def test_pathlib_path_objects_are_written_as_strings(value):
-    path_value = toml.dumps({"value": value})
+def test_pathlib_path_objects_are_written_as_strings():
+    pathlib = pytest.importorskip("pathlib")
+    path_value = toml.dumps({"value": pathlib.Path("test-path")})
+    assert path_value == 'value = "test-path"\n'
+
+
+def test_pathlib_purepath_objects_are_written_as_strings():
+    pathlib = pytest.importorskip("pathlib")
+    path_value = toml.dumps({"value": pathlib.PurePath("test-path")})
     assert path_value == 'value = "test-path"\n'

--- a/test/test_writer.py
+++ b/test/test_writer.py
@@ -25,3 +25,9 @@ def test_pathlib_purepath_objects_are_written_as_strings():
     pathlib = pytest.importorskip("pathlib")
     path_value = toml.dumps({"value": pathlib.PurePath("test-path")})
     assert path_value == 'value = "test-path"\n'
+
+
+def test_pathlib_purepath_objects_contents_are_escaped():
+    pathlib = pytest.importorskip("pathlib")
+    path_value = toml.dumps({"value": pathlib.PurePath('C:\\Escape\"this string"')})
+    assert path_value == 'value = "C:\\\\Escape\\"this string\\""\n'


### PR DESCRIPTION
This is a tentative PR (not yet ready for merging). 
Proposal; When presented with a python `PurePath` (ie `pathlib`) object, `pytoml` should serialize the object as a regular string. 

@avakar If you're in agreement, I can work on this for backward compatibility (currently this will only work for versions of python that are aware of `pathlib`). 

Also - I'm having some trouble getting the `toml-test` tests to pass. I think there's an issue with date serialization (but that's a separate issue). 