### PR TITLE
Document that the project is not being maintained

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 [![PyPI](https://img.shields.io/pypi/v/pytoml.svg)](https://pypi.python.org/pypi/pytoml)
 [![Build Status](https://travis-ci.org/avakar/pytoml.svg?branch=master)](https://travis-ci.org/avakar/pytoml)
 
+# Deprecated
+
+The pytoml project is no longer being actively maintained. Consider using the
+[toml](https://github.com/uiri/toml) package instead.
+
 # pytoml
 
 This project aims at being a specs-conforming and strict parser and writer for [TOML][1] files.


### PR DESCRIPTION
Recommend using uiri's toml package instead.

Refs #43 

---

Please feel free to close this if you disagree with it. But I was trying to decide which project to pick and was confused by the fact that pip chose pytoml and others (like black) chose toml. Thanks!